### PR TITLE
Power select modal compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This README outlines the details of using and collaborating on this Ember addon.
 ## Installation
 
 Add the following the list of dependencies in your `package.json` which can be found in the `app-ember` directory:
-- `"ember-bootstrap-controls": "wildland/ember-bootstrap-controls#v0.8.0",`
+- `"ember-bootstrap-controls": "wildland/ember-bootstrap-controls#v0.8.1",`
 
 Now run `npm install`.
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ export default Ember.Controller.extend({
 - `searchEnabled` - When falsey, hides the search in single selects
 - `searchField` - When the options are objects and no custom matches function is provided, this option tells the component what property of the options should the default matches use to filter
 - `disabled` - When truthy the component cannot be interacted
+- `renderInPlace` - When truthy, the list of options will be rendered in place instead of being attaches to the root of the body and positioned with javascript. Enabling this option also adds a wrapper div around the trigger and the content with class .ember-power-select. Useful when the power-select is inside of a modal.
 - `matcher` - Sometimes the default matcher is not enough for you, for example if you need to match against several fields or you need to perform fuzzy matching. If that is the case just pass your own matcher function. It will receive the option and the search term and you can do whatever you feel like inside as long as it returns -1 if it doesn't match and a positive number if it does.
 
 Example `matcher` that searches from the start of each item string:

--- a/addon/components/bootstrap-multi-select.js
+++ b/addon/components/bootstrap-multi-select.js
@@ -14,6 +14,7 @@ export default Ember.Component.extend(InputableMixin, {
 
   disabled: false,
   loadingMessage: null,
+  renderInPlace: false,
   allowClear: false,
   searchEnabled: false,
   searchField: null,

--- a/addon/components/bootstrap-power-select.js
+++ b/addon/components/bootstrap-power-select.js
@@ -15,6 +15,7 @@ export default Ember.Component.extend(InputableMixin, {
 
   disabled: false,
   loadingMessage: 'Loading',
+  renderInPlace: false,
   allowClear: false,
   searchEnabled: false,
   searchField: null,

--- a/addon/templates/components/bootstrap-multi-select.hbs
+++ b/addon/templates/components/bootstrap-multi-select.hbs
@@ -13,6 +13,7 @@
       searchField=searchField
       allowClear=allowClear
       disabled=disabled
+      renderInPlace=renderInPlace
       as |option|}}
       {{yield option}}
     {{/power-select-multiple}}

--- a/addon/templates/components/bootstrap-power-select.hbs
+++ b/addon/templates/components/bootstrap-power-select.hbs
@@ -16,6 +16,7 @@
         searchField=searchField
         allowClear=allowClear
         disabled=disabled
+        renderInPlace=renderInPlace
         as |option|}}
         {{yield option}}
       {{/power-select}}
@@ -31,6 +32,7 @@
         searchField=searchField
         allowClear=allowClear
         disabled=disabled
+        renderInPlace=renderInPlace
         as |option|}}
         {{yield option}}
       {{/power-select}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bootstrap-controls",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The default blueprint for ember-cli addons.",
   "private": true,
   "directories": {


### PR DESCRIPTION
This allows power-select to render on top of modals when used as a component inside one.
