### PR TITLE
Create table control

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ export default Ember.Route.extend(PaginatedRouteMixin, { //Extend from the mixin
   * `idOnRoute` - Boolean, when `true` adds the id of the row's model to the url (used mainly for show and edit routes).
   * `url` - String value of Ember route (i.e. `"posts.show"`)
 
-*All optional argument values are `false` as default*
+*All optional argument values are* `false` *as default*
 
 **Note:** Width is determined by size of the table's parent element.
 

--- a/README.md
+++ b/README.md
@@ -528,6 +528,17 @@ export default Ember.Route.extend(PaginatedRouteMixin, { //Extend from the mixin
 
 *All optional argument values are* `false` *as default*
 
+*Styling:*
+
+Adding custom styling to the table is simple, just add a few handy class selectors to your css, scss, or less files and style normally. Here are the class selectors:
+
+- `ember-bs-data-table-control` - The outside wrap `<div>` for the table component.
+- `ember-bs-data-table` - Selector for the `<table>` element itself
+- `ember-bs-table-header-row` - The `<tr>` element inside of `<thead>`.
+- `ember-bs-table-header-cell` - The `<td>` element inside of `<thead>`.
+- `ember-bs-table-row` - The `<tr>` element inside of `<tbody>`.
+- `ember-bs-table-cell` - The `<td>` element inside of `<tbody>`.
+
 **Note:** Width is determined by size of the table's parent element.
 
 For more information on Bootstrap style tables, visit the [Bootstrap](http://getbootstrap.com/css/#tables) website.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Move into your root ember directory `app-ember` and run:
 - [`bootstrap-power-select` select tag helper](#bootstrap-power-select)
 - [`bootstrap-multi-select` multi-select tag helper](#bootstrap-multi-select)
 - [`bootstrap-pagination-nav` pagination navigation helper](#bootstrap-pagination-nav)
+- [`bootstrap-data-table` table helper](#bootstrap-data-table)
 
 ---
 
@@ -429,6 +430,107 @@ export default Ember.Route.extend(PaginatedRouteMixin, { //Extend from the mixin
   },
 });
 ```
+
+---
+
+### Bootstrap Data Table
+
+*Use Example:*
+
+```html
+{{bootstrap-data-table
+  dataArray=users
+  title="User Index"
+  bordered=true
+  columns=(array
+    (hash
+      attr="fullName"
+      label="Name"
+    )
+    (hash
+      attr="username"
+      label="Username"
+      hasLink=true
+      idOnRoute=true
+      url="users.show"
+    )
+    (hash
+      attr="phone"
+      label="Contact #"
+    )
+    (hash
+      attr="email"
+      label="Email"
+      hasLink=true
+      idOnRoute=false
+      url="contacts.index"
+    )
+  )
+}}
+```
+
+*Rendered Output:*
+
+```html
+<h3 class="text-center">{{title}}</h3>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Username</th>
+      <th>Contact #</th>
+      <th>Email</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{user.fullName}}</td>
+      <td><a href="users/show/:id">{{user.username}}</a></td>
+      <td>{{user.phone}}</td>
+      <td><a href="contacts/index">{{user.email}}</a></td>
+    </tr>
+    <tr>
+      <td>{{user.fullName}}</td>
+      <td><a href="users/show/:id">{{user.username}}</a></td>
+      <td>{{user.phone}}</td>
+      <td><a href="contacts/index">{{user.email}}</a></td>
+    </tr>
+    <tr>
+      <td>{{user.fullName}}</td>
+      <td><a href="users/show/:id">{{user.username}}</a></td>
+      <td>{{user.phone}}</td>
+      <td><a href="contacts/index">{{user.email}}</a></td>
+    </tr>
+    <!-- ...etc... -->
+  </tbody>
+</table>
+```
+
+*Required Arguments:*
+- `dataArray` - Array of Ember models to display on the table as rows (**Note:** At this time only Ember model objects work in the `dataArray`).
+- `columns` - Array of **Hashes** containing column data.
+  * `attr` - Name of Model's attribute to be displayed in column.
+  * `label` - String displayed as the column's header text.
+
+*Optional Arguments:*
+- `title` - String displayed as the table's title.
+- `titleSmall` - Boolean, when `true` reduces the size of the table's title.
+- `striped` - Boolean, when `true` adds alternating shaded rows to table.
+- `responsive` - Boolean, when `true` enabled horizontal scrolling on table and hides y-axis overflow.
+- `bordered` - Boolean, when `true` adds border to table and columns
+- `canHover` - Boolean, when `true` enables row shading on mouse hover.
+- `condensed` - Boolean, when `true` removes cell padding for a smaller table.
+- `numberedRows` - Boolean, when `true` displays row number in first column.
+  * *Optional Column Arguments*
+  * `hasLink` - Boolean, when `true` wraps the column's content in a link tag.
+  * `idOnRoute` - Boolean, when `true` adds the id of the row's model to the url (used mainly for show and edit routes).
+  * `url` - String value of Ember route (i.e. `"posts.show"`)
+
+*All optional argument values are `false` as default*
+
+**Note:** Width is determined by size of the table's parent element.
+
+For more information on Bootstrap style tables, visit the [Bootstrap](http://getbootstrap.com/css/#tables) website.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,11 @@ export default Ember.Route.extend(PaginatedRouteMixin, { //Extend from the mixin
       idOnRoute=false
       url="contacts.index"
     )
+    (hash
+      attr="employment_organization.label"
+      label="Work"
+    )
+    <!-- NOTE: When calling an association of the dataArray model, you must use snke case instead oc camel case. -->
   )
 }}
 ```

--- a/addon/components/bootstrap-data-table.js
+++ b/addon/components/bootstrap-data-table.js
@@ -14,5 +14,4 @@ export default Ember.Component.extend({
   hasLink: null,
   idOnRoute: null,
   url: null,
-
 });

--- a/addon/components/bootstrap-data-table.js
+++ b/addon/components/bootstrap-data-table.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import layout from '../templates/components/bootstrap-data-table';
+
+export default Ember.Component.extend({
+  layout: layout,
+  dataArray: null,
+  title: null,
+  striped: null,
+  responsive: null,
+  bordered: null,
+  canHover: null,
+  condensed: null,
+  numberedRows: null,
+  hasLink: null,
+  idOnRoute: null,
+  url: null,
+
+});

--- a/addon/helpers/add-numbers.js
+++ b/addon/helpers/add-numbers.js
@@ -6,7 +6,5 @@ export default function addNumbers(params) {
   for (let i = 1; i < params.length; i++) {
     result = result + params[i];
   }
-
   return result;
 }
-

--- a/addon/helpers/parse-columns.js
+++ b/addon/helpers/parse-columns.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export function parseColumns(params/*, hash*/) {
+  let record = params[0];
+  let attrName = params[1];
+
+  let result = record.get(attrName);
+
+  return new Ember.Handlebars.SafeString(result);
+}
+
+export default Ember.Helper.helper(parseColumns);

--- a/addon/templates/components/bootstrap-data-table.hbs
+++ b/addon/templates/components/bootstrap-data-table.hbs
@@ -1,0 +1,45 @@
+<div class="bootstrap-data-table-component" style="padding: 5px">
+  {{#if title}}
+    <div class="row">
+      <div class="col-md-12">
+        {{#if titleSmall}}
+          <p class="lead text-center">{{title}}</p>
+        {{else}}
+          <h3 class="text-center">{{title}}</h3>
+        {{/if}}
+      </div>
+    </div>
+  {{/if}}
+  <table class="table {{if striped 'table-striped'}} {{if responsive 'table-responsive'}} {{if bordered 'table-bordered'}} {{if canHover 'table-hover'}} {{if condensed 'table-condensed'}}" style="background-color: white">
+    <thead>
+      <tr>
+        {{#if numberedRows}}
+          <th>&#35;</th>
+        {{/if}}
+        {{#each columns as |column|}}
+          <th>{{column.label}}</th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each dataArray as |item index|}}
+        <tr>
+          {{#if numberedRows}}
+            <td>{{add-numbers index 1}}</td>
+          {{/if}}
+          {{#each columns as |column|}}
+            {{#if column.hasLink}}
+              {{#if column.idOnRoute}}
+                <td>{{#link-to column.url item}}{{parse-columns item column.attr}}{{/link-to}}</td>
+              {{else}}
+                <td>{{#link-to column.url}}{{parse-columns item column.attr}}{{/link-to}}</td>
+              {{/if}}
+            {{else}}
+              <td>{{parse-columns item column.attr}}</td>
+            {{/if}}
+          {{/each}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/addon/templates/components/bootstrap-data-table.hbs
+++ b/addon/templates/components/bootstrap-data-table.hbs
@@ -1,4 +1,4 @@
-<div class="bootstrap-data-table-component" style="padding: 5px">
+<div class="bootstrap-data-table-component ember-bs-data-table-control {{if responsive 'table-responsive'}}">
   {{#if title}}
     <div class="row">
       <div class="col-md-12">
@@ -10,32 +10,32 @@
       </div>
     </div>
   {{/if}}
-  <table class="table {{if striped 'table-striped'}} {{if responsive 'table-responsive'}} {{if bordered 'table-bordered'}} {{if canHover 'table-hover'}} {{if condensed 'table-condensed'}}" style="background-color: white">
+  <table class="table ember-bs-data-table {{if striped 'table-striped'}} {{if bordered 'table-bordered'}} {{if canHover 'table-hover'}} {{if condensed 'table-condensed'}}">
     <thead>
-      <tr>
+      <tr class="ember-bs-table-header-row">
         {{#if numberedRows}}
-          <th>&#35;</th>
+          <th class="ember-bs-table-header-cell">&#35;</th>
         {{/if}}
         {{#each columns as |column|}}
-          <th>{{column.label}}</th>
+          <th class="ember-bs-table-header-cell">{{column.label}}</th>
         {{/each}}
       </tr>
     </thead>
     <tbody>
       {{#each dataArray as |item index|}}
-        <tr>
+        <tr class="ember-bs-table-row">
           {{#if numberedRows}}
-            <td>{{add-numbers index 1}}</td>
+            <td class="ember-bs-table-cell">{{add-numbers index 1}}</td>
           {{/if}}
           {{#each columns as |column|}}
             {{#if column.hasLink}}
               {{#if column.idOnRoute}}
-                <td>{{#link-to column.url item}}{{parse-columns item column.attr}}{{/link-to}}</td>
+                <td class="ember-bs-table-cell">{{#link-to column.url item}}{{parse-columns item column.attr}}{{/link-to}}</td>
               {{else}}
-                <td>{{#link-to column.url}}{{parse-columns item column.attr}}{{/link-to}}</td>
+                <td class="ember-bs-table-cell">{{#link-to column.url}}{{parse-columns item column.attr}}{{/link-to}}</td>
               {{/if}}
             {{else}}
-              <td>{{parse-columns item column.attr}}</td>
+              <td class="ember-bs-table-cell">{{parse-columns item column.attr}}</td>
             {{/if}}
           {{/each}}
         </tr>

--- a/app/components/bootstrap-data-table.js
+++ b/app/components/bootstrap-data-table.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap-controls/components/bootstrap-data-table';

--- a/app/helpers/parse-columns.js
+++ b/app/helpers/parse-columns.js
@@ -1,0 +1,1 @@
+export { default, parseColumns } from 'ember-bootstrap-controls/helpers/parse-columns';

--- a/index.js
+++ b/index.js
@@ -2,5 +2,8 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-bootstrap-controls'
+  name: 'ember-bootstrap-controls',
+  // isDevelopingAddon: function() {
+  //   return true;
+  // }
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   name: 'ember-bootstrap-controls',
-  // isDevelopingAddon: function() {
-  //   return true;
-  // }
+  isDevelopingAddon: function() {
+    return true;
+  }
 };

--- a/tests/integration/components/bootstrap-data-table-test.js
+++ b/tests/integration/components/bootstrap-data-table-test.js
@@ -1,0 +1,26 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('bootstrap-data-table', 'Integration | Component | bootstrap data table', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{bootstrap-data-table}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#bootstrap-data-table}}
+      template block text
+    {{/bootstrap-data-table}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/helpers/parse-columns-test.js
+++ b/tests/unit/helpers/parse-columns-test.js
@@ -1,0 +1,10 @@
+import { parseColumns } from '../../../helpers/parse-columns';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | parse columns');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var result = parseColumns(42);
+  assert.ok(result);
+});


### PR DESCRIPTION
Added control for generating Bootstrap tables. 

Users can add links to columns, the links themselves are able to then be either an id required route or not, they can also provide a title for the table, or number the rows, as well as add any stylings given by the various Bootstrap `<table>` classes.

There is understandably a lot more that we could add to this. However, too much complexity might make using the generator a bit pointless versus creating your own table.