### PR TITLE
Fixes #72 - Deprecation Warning for Input type checkbox

### DIFF
--- a/addon/components/bootstrap-input.js
+++ b/addon/components/bootstrap-input.js
@@ -58,6 +58,18 @@ export default Ember.Component.extend(InputableMixin, {
     }
   }),
 
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    if(this.get('type') === 'checkbox') {
+      Ember.deprecate(
+        "This component will be removed in the next minor version of ember-bootstrap-controls. Please use `bootstrap-checkbox` instead of `bootstrap-input` with checkbox type for checkboxes.",
+        false, // always raise depecation
+        { id: 'ember-bootstrap-controls' }
+      );
+    }
+  },
+
   actions: {
     keyPress: function() {
       this.sendAction('key-press', ...arguments);

--- a/addon/components/freestyle/bootstrap-input.js
+++ b/addon/components/freestyle/bootstrap-input.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import layout from '../../templates/components/freestyle/bootstrap-input';
+
+export default Ember.Component.extend({
+  layout: layout,
+  value: "test",
+  inputId: 1,
+  type: "text",
+  readonly: false,
+  disabled: false,
+  actions: {
+    keyPress() {
+      console.log('key pressed');
+    },
+    keyUp() {
+      console.log('key up');
+    },
+    keyDown() {
+      console.log('key down');
+    },
+  },
+});

--- a/addon/helpers/parse-columns.js
+++ b/addon/helpers/parse-columns.js
@@ -6,7 +6,7 @@ export function parseColumns(params/*, hash*/) {
 
   let result = record.get(attrName);
 
-  return new Ember.Handlebars.SafeString(result);
+  return new Ember.String.htmlSafe(result);
 }
 
 export default Ember.Helper.helper(parseColumns);

--- a/addon/templates/components/ember-bootstrap-controls-freestyle.hbs
+++ b/addon/templates/components/ember-bootstrap-controls-freestyle.hbs
@@ -1,4 +1,6 @@
 {{#freestyle-section name='Bootstrap Controls' as |section|}}
+  {{freestyle/bootstrap-input
+    section=section}}
   {{freestyle/bootstrap-checkbox
     section=section}}
   {{freestyle/bootstrap-checkbox-button

--- a/addon/templates/components/freestyle/bootstrap-input.hbs
+++ b/addon/templates/components/freestyle/bootstrap-input.hbs
@@ -1,0 +1,24 @@
+{{#freestyle-subsection name="Input" section=section}}
+  {{#freestyle-collection title='Input' defaultKey='input-text' inline=true as |collection|}}
+
+    {{#freestyle-variant collection=collection key='input-text'}}
+      {{#freestyle-usage "input-text" title="Input Text"}}
+
+        {{bootstrap-input
+          value=value
+          type=type
+          placeholder="Input Field"
+          label="Input Field"
+          classNames="form-control"
+          readonly=readonly
+          disabled=disabled
+          key-press=(action 'keyPress')
+          key-up=(action 'keyUp')
+          key-down=(action 'keyDown')
+          required=false}}
+
+      {{/freestyle-usage}}
+    {{/freestyle-variant}}
+
+  {{/freestyle-collection}}
+{{/freestyle-subsection}}

--- a/addon/utils/computed-action-key.js
+++ b/addon/utils/computed-action-key.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-export default function computerActionKey(dependentActionKey) {
-  var camelCaseActionKey = dependentActionKey.camelize();
+export default function computedActionKey(dependentActionKey) {
+  var camelCaseActionKey = Ember.String.camelize(dependentActionKey);
 
   return Ember.computed(dependentActionKey, function() {
     return this.get(dependentActionKey) ? camelCaseActionKey : null;

--- a/addon/utils/computer-action-key.js
+++ b/addon/utils/computer-action-key.js
@@ -1,8 +1,0 @@
-import Ember from 'ember';
-export default function computerActionKey(dependentActionKey) {
-  var camelCaseActionKey = dependentActionKey.camelize();
-
-  return Ember.computed(dependentActionKey, function() {
-    return this.get(dependentActionKey) ? camelCaseActionKey : null;
-  });
-}

--- a/app/components/freestyle/bootstrap-input.js
+++ b/app/components/freestyle/bootstrap-input.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap-controls/components/freestyle/bootstrap-input';


### PR DESCRIPTION
Added Deprecation for checkbox’s that are bootstrap-input components.