### PR TITLE
Ember cli updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+*.swp

--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
-  - EMBER_TRY_SCENARIO=default
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true
@@ -21,14 +25,16 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,6 @@
 {
   "name": "ember-bootstrap-controls",
   "dependencies": {
-    "ember": "~2.10.0",
-    "ember-cli-shims": "0.1.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.7",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.7",
-    "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1",
     "remarkable": "1.6.2",
     "highlightjs": "9.1.0",
     "bootstrap-datepicker": "^1.6.4",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -10,6 +10,11 @@ module.exports = {
         resolutions: {
           'ember': 'lts-2-4'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -20,6 +25,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -32,6 +42,11 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -42,6 +57,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -54,6 +74,17 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -2,8 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-bootstrap-controls',
-  isDevelopingAddon: function() {
-    return true;
-  }
+  name: 'ember-bootstrap-controls'
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.7"
-    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars": "^1.1.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -7,56 +7,58 @@
     "ember-addon"
   ],
   "license": "MIT",
+  "author": "",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
+  "repository": "",
   "scripts": {
     "build": "ember build",
-    "clean": "rm -rf node_modules/ bower_components/ && npm cache clean && bower cache clean && npm install && bower install",
-    "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -",
     "start": "ember server",
     "test": "ember try:each"
   },
-  "repository": "",
   "engines": {
     "node": ">= 4.0.0"
   },
-  "author": "",
+  "dependencies": {
+    "ember-cli-babel": "^5.1.7"
+    "ember-cli-htmlbars": "^1.1.1",
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
     "ember-bootstrap": "0.11.3",
-    "ember-browserify": "~1.1.11",
-    "ember-cli": "^2.10.0",
+    "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-bootstrap-datepicker": "~0.5.6",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-github-pages": "0.1.2",
-    "ember-cli-htmlbars": "^1.0.10",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sass": "5.6.0",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-concurrency": "0.7.19",
+    "ember-data": "^2.11.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-freestyle": "~0.2.13",
-    "ember-load-initializers": "^0.5.1",
     "ember-power-select": "1.4.0",
+    "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-text-mask": "~0.1.0",
     "ember-truth-helpers": "~1.2.0",
-    "loader.js": "^4.0.10",
     "text-mask-addons": "~1.0.1"
+    "ember-source": "~2.11.0",
+    "loader.js": "^4.0.10"
   },
-  "dependencies": {
-    "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "0.7.9"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
     "ember-bootstrap": "0.11.3",
+    "ember-browserify": "~1.1.11",
     "ember-cli": "2.11.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-bootstrap-datepicker": "~0.5.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">= 4.0.0"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,9 @@
     "ember-resolver": "^2.0.3",
     "ember-text-mask": "~0.1.0",
     "ember-truth-helpers": "~1.2.0",
-    "text-mask-addons": "~1.0.1"
+    "text-mask-addons": "~1.0.1",
     "ember-source": "~2.11.0",
     "loader.js": "^4.0.10"
-  },
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -43,8 +43,6 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.locationType = 'hash';
-    ENV.rootURL = '/ember-bootstrap-controls/';
 
   }
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  // use defaults, but you can override
-  let attributes = Ember.assign({}, config.APP, attrs);
+  let attributes = Ember.merge({}, config.APP);
+  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Updates ember-bootstrap-controls to the latest ember-cli and most importantly uses `"ember-cli-htmlbars": "^1.1.1"`. This is likely breaking and needs a minor version bump after merge and before release.