### PR TITLE
Mask Input Disable ability

### DIFF
--- a/addon/components/bootstrap-mask-input.js
+++ b/addon/components/bootstrap-mask-input.js
@@ -15,6 +15,7 @@ export default Ember.Component.extend(InputableMixin, {
   srOnly: null,
   tabindex: 0,
   required: false,
+  disabled: false,
 
   mask: null,
   placeholderChar: '_',

--- a/addon/templates/components/bootstrap-mask-input.hbs
+++ b/addon/templates/components/bootstrap-mask-input.hbs
@@ -12,6 +12,7 @@
       key-down=key-down
       elementId=inputGuid
       required=required
+      disabled=disabled
       keepCharPositions=keepCharPositions
       classNames="form-control"
       placeholder=placeholder}}


### PR DESCRIPTION
Adds ability to mark the `bootstrap-mask-input` component as disabled