### PR TITLE
Fix ember 2.14 errors with makeBoundHelper not working

### DIFF
--- a/addon/helpers/add-numbers.js
+++ b/addon/helpers/add-numbers.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default function addNumbers(params) {
+export function addNumbers(params) {
   let result = params[0];
 
   for (let i = 1; i < params.length; i++) {
@@ -8,3 +8,5 @@ export default function addNumbers(params) {
   }
   return result;
 }
+
+export default Ember.Helper.helper(addNumbers);

--- a/addon/helpers/minus-numbers.js
+++ b/addon/helpers/minus-numbers.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default function minusNumbers(params) {
+export function minusNumbers(params) {
   var result = params[0];
 
   for (var i = 1; i < params.length; i++) {
@@ -9,3 +9,5 @@ export default function minusNumbers(params) {
 
   return result;
 }
+
+export default Ember.Helper.helper(minusNumbers);

--- a/addon/utils/-register-helper.js
+++ b/addon/utils/-register-helper.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-let registerHelper = Ember.Helper.helper ? Ember.Helper.helper : Ember.HTMLBars.makeBoundHelper;
-
-export default function registerHelper(helper) {
-  return registerHelper(helper);
-}

--- a/addon/utils/-register-helper.js
+++ b/addon/utils/-register-helper.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+let registerHelper = Ember.Helper.helper ? Ember.Helper.helper : Ember.HTMLBars.makeBoundHelper;
+
+export default function registerHelper(helper) {
+  return registerHelper(helper);
+}

--- a/app/helpers/add-numbers.js
+++ b/app/helpers/add-numbers.js
@@ -1,2 +1,1 @@
-import addNumbers from 'ember-bootstrap-controls/helpers/add-numbers';
-export default Ember.HTMLBars.makeBoundHelper(addNumbers);
+export { default, addNumbers } from 'ember-bootstrap-controls/helpers/add-numbers';

--- a/app/helpers/minus-numbers.js
+++ b/app/helpers/minus-numbers.js
@@ -1,2 +1,1 @@
-import minusNumbers from 'ember-bootstrap-controls/helpers/minus-numbers';
-export default Ember.HTMLBars.makeBoundHelper(minusNumbers);
+export { default,  minusNumbers } from 'ember-bootstrap-controls/helpers/minus-numbers';


### PR DESCRIPTION
Fixes an issue where makeBoundHelper isn't available anymore in 2.14 (has been deprecated in favor of Ember.Helper.helper) since 1.13.