### PR TITLE
Dasherize keyUp, keyDown, and keyPress attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Ember-bootstrap-controls is a small library for quickly creating EmberJS forms t
 This README outlines the details of using and collaborating on this Ember addon.
 
 ## Upgrade Instructions
+### 0.14.0 - 0.15.0
+ - `keyPress`, `keyDown`, `keyUp` events were all renamed to `key-press`, `key-down`, and `key-up` respectively. This was to prevent it from conflicting with Ember.Component `keyPress`, `keyDown`, and `keyUp` events. An assert is thrown to help the developer identify and fix these issues, but it is further recommeneded to do a project find, and replace where used.
+
+### 0.X - 0.14.0
 ### This version is likely not backwards compatible with ember-cli < 2.11.0 and ember-cli-htmlbars < 1.1.1
 ### If you need to support a version less than one of these, please use 0.11.x instead.
  - Find the `ember-bootstrap-controls` in your `package.json` which can be found in the root ember directory and update the version to the latest release.

--- a/addon/components/bootstrap-currency-input.js
+++ b/addon/components/bootstrap-currency-input.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/bootstrap-currency-input';
 import InputableMixin from '../mixins/components/inputable';
-import computedActionKey from '../utils/computed-action-key';
+import asserIfUsingRenamedEvents from '../utils/assert-if-using-renamed-events';
 import { createNumberMask } from '../text-mask-addons';
 
 const { Component } = Ember;
@@ -20,9 +20,6 @@ export default Component.extend(InputableMixin, {
   required: true,
 
   currencyMask: createNumberMask({ prefix: '$', allowDecimal: true, decimalLimit: 2 }),
-  keyPress: computedActionKey('key-press'),
-  keyUp: computedActionKey('key-up'),
-  keyDown: computedActionKey('key-down'),
 
   hasValue: Ember.computed('value', function() {
     const value = this.get('value');
@@ -30,17 +27,9 @@ export default Component.extend(InputableMixin, {
     return value ? true : false;
   }),
 
-  actions: {
-    keyPress: function() {
-      this.sendAction('key-press', ...arguments);
-    },
+  didReceiveAttrs() {
+    this._super(...arguments);
 
-    keyUp: function() {
-      this.sendAction('key-up', ...arguments);
-    },
-
-    keyDown: function() {
-      this.sendAction('key-down', ...arguments);
-    },
+    asserIfUsingRenamedEvents(this);
   },
 });

--- a/addon/components/bootstrap-input.js
+++ b/addon/components/bootstrap-input.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/bootstrap-input';
 import InputableMixin from '../mixins/components/inputable';
+import asserIfUsingRenamedEvents from '../utils/assert-if-using-renamed-events';
 
 export default Ember.Component.extend(InputableMixin, {
   layout: layout,
@@ -22,5 +23,7 @@ export default Ember.Component.extend(InputableMixin, {
     if (this.get('type') === 'checkbox') {
       Ember.assert("A type of 'checkbox' is not supported. Use  bootstrap-checkbox instead");
     }
+
+    asserIfUsingRenamedEvents(this);
   }
 });

--- a/addon/components/bootstrap-phone-mask-input.js
+++ b/addon/components/bootstrap-phone-mask-input.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/bootstrap-phone-mask-input';
 import InputableMixin from '../mixins/components/inputable';
+import asserIfUsingRenamedEvents from '../utils/assert-if-using-renamed-events';
 
 const { Component } = Ember;
 
@@ -19,4 +20,10 @@ export default Component.extend(InputableMixin, {
   required: true,
 
   phoneMask: ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/],
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    asserIfUsingRenamedEvents(this);
+  },
 });

--- a/addon/templates/components/bootstrap-currency-input.hbs
+++ b/addon/templates/components/bootstrap-currency-input.hbs
@@ -15,9 +15,9 @@
       classNames="form-control"
       readonly=readonly
       disabled=disabled
-      key-press=keyPress
-      key-up=keyUp
-      key-down=keyDown
+      key-press=key-press
+      key-up=key-up
+      key-down=key-down
       required=required}}
     {{#if errors}}
       <div class="form-control-static alert alert-danger" role="alert">

--- a/addon/templates/components/bootstrap-input.hbs
+++ b/addon/templates/components/bootstrap-input.hbs
@@ -11,9 +11,9 @@
     classNames="form-control"
     readonly=readonly
     disabled=disabled
-    key-press=keyPress
-    key-up=keyUp
-    key-down=keyDown
+    key-press=key-press
+    key-up=key-up
+    key-down=key-down
     required=required}}
   {{#if errors}}
     <div class="form-control-static alert alert-danger" role="alert">

--- a/addon/templates/components/bootstrap-phone-mask-input.hbs
+++ b/addon/templates/components/bootstrap-phone-mask-input.hbs
@@ -15,9 +15,9 @@
     disabled=disabled
     placeholder=placeholder
     placeholderChar=placeholderChar
-    key-press=keyPress
-    key-up=keyUp
-    key-down=keyDown
+    key-press=key-press
+    key-up=key-up
+    key-down=key-down
     required=required}}
   {{#if errors}}
     <div class="form-control-static alert alert-danger" role="alert">

--- a/addon/utils/assert-if-using-renamed-events.js
+++ b/addon/utils/assert-if-using-renamed-events.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default function asserIfUsingRenamedEvents(component) {
+  const keyPress = component.get('keyPress');
+  if (keyPress) {
+    assertEvent('keyPress');
+  }
+
+  const keyUp = component.get('keyUp');
+  if (keyUp) {
+    assertEvent('keyUp');
+  }
+
+  const keyDown = component.get('keyDown');
+  if (keyDown) {
+    assertEvent('keyDown');
+  }
+}
+
+function assertEvent(eventName) {
+  Ember.assert('This event has been renamed from `keyPress` to `key-press`, please rename occordingly');
+}


### PR DESCRIPTION
Dasherize keyUp, keyDown, and keyPress attributes to prevent conflicts with Ember.Component events.