### PR TITLE
Fix masked input

### DIFF
--- a/addon/components/bootstrap-mask-input.js
+++ b/addon/components/bootstrap-mask-input.js
@@ -1,47 +1,13 @@
 import Ember from 'ember';
 import layout from '../templates/components/bootstrap-mask-input';
-import InputableMixin from '../mixins/components/inputable';
 
-const { guidFor } = Ember;
+export const INPUT_MASK_CLASS_NAME = 'bootstrap-input-mask-component';
 
-export default Ember.Component.extend(InputableMixin, {
-  layout: layout,
+export default Ember.Component.extend({
   tagName: '',
-  classNames: '',
-  value: null,
-  readonly: null,
-  type: null,
-  srOnly: null,
-  tabindex: 0,
-  required: false,
-  disabled: false,
+  classNames: [INPUT_MASK_CLASS_NAME],
+  layout: layout,
 
-  mask: null,
   placeholderChar: '_',
-  placeholder: '',
   keepCharPositions: true,
-
-  guid: Ember.computed.readOnly('_guid'),
-  _guid: null,
-
-  /* action attrs */
-  'key-press': null,
-  'key-up': null,
-  'key-down': null,
-  'focus-out': null,
-
-  inputGuid: Ember.computed('guid', function() {
-    return `input-${this.get('guid')}`;
-  }),
-
-  hasValue: Ember.computed('value', function() {
-    const value = this.get('value');
-    return value ? true : false;
-  }),
-
-  init() {
-    this._super(...arguments);
-    const guid = guidFor(this);
-    this.set('_guid', guid);
-  }
 });

--- a/addon/templates/components/bootstrap-mask-input.hbs
+++ b/addon/templates/components/bootstrap-mask-input.hbs
@@ -1,26 +1,18 @@
-<div class="{{concat-class-names classNames}} form-group bootstrap-input-component {{if hasSuccess 'has-success'}} {{if hasWarning 'has-warning'}} {{if (or hasError (and required (not hasValue))) 'has-error'}}" id="{{elementId}}">
-  {{#if label}}
-    <label for="{{inputGuid}}" class="control-label">{{label}}</label>
-  {{/if}}
-    {{masked-input
-      mask=mask
-      placeholderChar=placeholderChar
-      value=(readonly value)
-      focus-out=focus-out
-      key-press=key-press
-      key-up=key-up
-      key-down=key-down
-      elementId=inputGuid
-      required=required
-      disabled=disabled
-      keepCharPositions=keepCharPositions
-      classNames="form-control"
-      placeholder=placeholder}}
-  {{#if errors}}
-    <div class="form-control-static alert alert-danger" role="alert">
-      {{#each errors as |error|}}
-        <span>{{error.message}}</span>
-      {{/each}}
-    </div>
-  {{/if}}
-</div>
+{{#bootstrap/control-wrapper classNames=classNames required=required srOnly=srOnly label=label as |control|}}
+  {{masked-input
+    value=value
+    mask=mask
+    guide=guide
+    placeholderChar=placeholderChar
+    keepCharPositions=keepCharPositions
+    pipe=pipe
+    showMask=showMask
+    conformToMask=conformToMask
+    enter=enter
+    insert-newline=insert-newline
+    escape-press=escape-press
+    focus-in=focus-in
+    focus-out=focus-out
+    key-press=key-press
+    key-up=key-up}}
+{{/bootstrap/control-wrapper}}


### PR DESCRIPTION
Previously, the value being passed into masked input was readonly,
preventing it from being mutated on change. This PR removes that and
switches this control over the HOC `bootstrap/control-wrapper`.