### PR TITLE
added back changeDate event to date picker

### DIFF
--- a/addon/templates/components/bootstrap-date-picker.hbs
+++ b/addon/templates/components/bootstrap-date-picker.hbs
@@ -11,6 +11,7 @@
     forceParse=forceParse
     format=format
     keyboardNavigation=keyboardNavigation
+    changeDate=changeDate
     language=language
     minViewMode=minViewMode
     multidate=multidate


### PR DESCRIPTION
The `changeDate` callback on the date picker was accidentally removed during the last set of changes (probably by me, this needs better tests...). This re-adds it to avoid regressions.