### PR TITLE
Add flexible input

### DIFF
--- a/addon/components/bootstrap-power-select-lazy.js
+++ b/addon/components/bootstrap-power-select-lazy.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import { POWER_SELECT_CLASS_NAME } from './bootstrap-power-select';
-import generateUUID from 'ember-bootstrap-controls/utils/generate-uuid';
 import layout from '../templates/components/bootstrap-power-select-lazy';
 import LazySelectState from '../utils/lazy-select-state';
 

--- a/addon/components/bootstrap/-input.js
+++ b/addon/components/bootstrap/-input.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.TextField.extend({
+  classNames: ['form-control'],
+});

--- a/addon/components/bootstrap/-label.js
+++ b/addon/components/bootstrap/-label.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import layout from '../../templates/components/bootstrap/-label';
+
+export default Ember.Component.extend({
+  layout,
+
+  tagName: 'label',
+  classNameBindings: ['srOnly:sr-only'],
+  attributeBindings: ['for'],
+});

--- a/addon/components/freestyle/bootstrap-input.js
+++ b/addon/components/freestyle/bootstrap-input.js
@@ -4,22 +4,4 @@ import layout from '../../templates/components/freestyle/bootstrap-input';
 
 export default Ember.Component.extend({
   layout: layout,
-
-  value: "test",
-  inputId: 1,
-  type: "text",
-  readonly: false,
-  disabled: false,
-
-  actions: {
-    keyPress() {
-      console.log('key pressed');
-    },
-    keyUp() {
-      console.log('key up');
-    },
-    keyDown() {
-      console.log('key down');
-    },
-  },
 });

--- a/addon/templates/components/bootstrap-date-picker.hbs
+++ b/addon/templates/components/bootstrap-date-picker.hbs
@@ -1,4 +1,5 @@
-{{#bootstrap/control-wrapper classNames=classNames errors=errors required=required srOnly=srOnly label=label as |control|}}
+{{#bootstrap/control-wrapper classNames=classNames errors=errors as |control|}}
+  {{control.label for=control.inputId label=label srOnly=srOnly}}
   {{bootstrap-datepicker
     value=value
     classNames="form-control"

--- a/addon/templates/components/bootstrap-input.hbs
+++ b/addon/templates/components/bootstrap-input.hbs
@@ -1,15 +1,37 @@
-{{#bootstrap/control-wrapper classNames=classNames errors=errors srOnly=srOnly label=label as |control|}}
-  {{input
-    tabindex=tabindex
-    value=value
-    elementId=control.inputId
-    type=type
-    placeholder=placeholder
-    classNames="form-control"
-    readonly=readonly
-    disabled=disabled
-    key-press=key-press
-    key-up=key-up
-    key-down=key-down
-    required=required}}
+{{#bootstrap/control-wrapper classNames=classNames errors=errors as |control|}}
+  {{#if hasBlock}}
+    {{yield
+      (hash
+        label=(component control.label for=control.inputId srOnly=srOnly label=label)
+        input=(component 'bootstrap/-input'
+          value=value
+          elementId=control.inputId
+          type=type
+          placeholder=placeholder
+          classNames="form-control"
+          readonly=readonly
+          disabled=disabled
+          key-press=key-press
+          key-up=key-up
+          key-down=key-down
+          required=required
+        )
+      )
+    }}
+  {{else}}
+    {{control.label for=control.inputId label=label srOnly=srOnly}}
+    {{bootstrap/-input
+      tabindex=tabindex
+      value=value
+      elementId=control.inputId
+      type=type
+      placeholder=placeholder
+      readonly=readonly
+      disabled=disabled
+      key-press=key-press
+      key-up=key-up
+      key-down=key-down
+      required=required
+    }}
+  {{/if}}
 {{/bootstrap/control-wrapper}}

--- a/addon/templates/components/bootstrap-mask-input.hbs
+++ b/addon/templates/components/bootstrap-mask-input.hbs
@@ -1,21 +1,51 @@
-{{#bootstrap/control-wrapper errors=errors classNames=classNames required=required srOnly=srOnly label=label as |control|}}
-  {{masked-input
-    classNames="form-control"
-    value=value
-    disabled=disabled
-    mask=mask
-    guide=guide
-    placeholder=placeholder
-    placeholderChar=placeholderChar
-    keepCharPositions=keepCharPositions
-    pipe=pipe
-    showMask=showMask
-    conformToMask=conformToMask
-    enter=enter
-    insert-newline=insert-newline
-    escape-press=escape-press
-    focus-in=focus-in
-    focus-out=focus-out
-    key-press=key-press
-    key-up=key-up}}
+{{#bootstrap/control-wrapper errors=errors classNames=classNames as |control|}}
+  {{#if hasBlock}}
+    {{yield
+      (hash
+        label=(component control.label for=control.inputId label=label srOnly=srOnly)
+        input=(component 'masked-input'
+          classNames="form-control"
+          value=value
+          disabled=disabled
+          mask=mask
+          guide=guide
+          placeholder=placeholder
+          placeholderChar=placeholderChar
+          keepCharPositions=keepCharPositions
+          pipe=pipe
+          showMask=showMask
+          conformToMask=conformToMask
+          enter=enter
+          insert-newline=insert-newline
+          escape-press=escape-press
+          focus-in=focus-in
+          focus-out=focus-out
+          key-press=key-press
+          key-up=key-up
+        )
+      )
+    }}
+  {{else}}
+    {{control.label for=control.inputId label=label srOnly=srOnly}}
+    {{masked-input
+      classNames="form-control"
+      value=value
+      disabled=disabled
+      mask=mask
+      guide=guide
+      placeholder=placeholder
+      placeholderChar=placeholderChar
+      keepCharPositions=keepCharPositions
+      pipe=pipe
+      showMask=showMask
+      conformToMask=conformToMask
+      enter=enter
+      insert-newline=insert-newline
+      escape-press=escape-press
+      focus-in=focus-in
+      focus-out=focus-out
+      key-press=key-press
+      key-up=key-up
+    }}
+  {{/if}}
 {{/bootstrap/control-wrapper}}

--- a/addon/templates/components/bootstrap-multi-select-lazy.hbs
+++ b/addon/templates/components/bootstrap-multi-select-lazy.hbs
@@ -1,6 +1,7 @@
-{{#bootstrap/control-wrapper classNames=classNames errors=errors ariaLabelledBy=true srOnly=srOnly label=label as |control|}}
+{{#bootstrap/control-wrapper classNames=classNames errors=errors as |control|}}
+  {{control.label elementId=control.inputId srOnly=srOnly label=label}}
   {{#power-select-multiple
-    ariaLabelledBy=control.labelId
+    ariaLabelledBy=control.inputId
     selected=selected
     placeholder=placeholder
     loadingMessage=loadingMessage

--- a/addon/templates/components/bootstrap-power-select-lazy.hbs
+++ b/addon/templates/components/bootstrap-power-select-lazy.hbs
@@ -1,6 +1,7 @@
-{{#bootstrap/control-wrapper errors=errors classNames=classNames ariaLabelledBy=true srOnly=srOnly label=label as |control|}}
+{{#bootstrap/control-wrapper errors=errors classNames=classNames as |control|}}
+  {{control.label elementId=control.inputId srOnly=srOnly label=label}}
   {{#power-select
-    ariaLabelledBy=control.labelId
+    ariaLabelledBy=control.inputId
     selected=selected
     placeholder=placeholder
     loadingMessage=loadingMessage

--- a/addon/templates/components/bootstrap/-label.hbs
+++ b/addon/templates/components/bootstrap/-label.hbs
@@ -1,0 +1,1 @@
+{{#if hasBlock}}{{yield}}{{else}}{{label}}{{/if}}

--- a/addon/templates/components/bootstrap/control-wrapper.hbs
+++ b/addon/templates/components/bootstrap/control-wrapper.hbs
@@ -1,5 +1,4 @@
-<label for="{{if ariaLabelledBy '' inputId}}" id="{{if ariaLabelledBy inputId}}" class="control-label {{if srOnly 'sr-only' ''}}">{{label}}</label>
-{{yield (if ariaLabelledBy (hash labelId=inputId) (hash inputId=inputId))}}
+{{yield (hash label=(component 'bootstrap/-label' classNames=(if srOnly 'control-label sr-only' 'control-label')) inputId=inputId)}}
 {{#if errors}}
   <div class="alert alert-danger" role="alert">
     {{#each errors as |error|}}

--- a/addon/templates/components/freestyle/bootstrap-input.hbs
+++ b/addon/templates/components/freestyle/bootstrap-input.hbs
@@ -1,18 +1,60 @@
 {{#section.subsection name="Input"}}
   {{#freestyle-collection title='Input' defaultKey='input-text' inline=true as |collection|}}
     {{#collection.variant key='input-text'}}
-      {{#freestyle-usage "input-text" title="Input Text"}}
+      {{#freestyle-usage "input-text" title="Basic Input Usage"}}
         {{bootstrap-input
           value=value
-          type=type
           placeholder="Input Field"
           label="Input Field"
-          readonly=readonly
-          disabled=disabled
-          key-press=(action 'keyPress')
-          key-up=(action 'keyUp')
-          key-down=(action 'keyDown')
-          required=false}}
+        }}
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+    {{#collection.variant key='input-text-no-label'}}
+      {{#freestyle-usage "input-text-no-label" title="Input Without Label"}}
+        {{bootstrap-input
+          value=value
+          placeholder="Input Field"
+          label="Input Field"
+          srOnly=true
+        }}
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+    {{#collection.variant key='input-text-fancy'}}
+      {{#freestyle-usage "input-text-fancy" title="Fancy Looking Input"}}
+        {{#bootstrap-input
+          value=value
+          placeholder="Some Number"
+          label="Dollars"
+          srOnly=true
+          as |control|
+        }}
+          {{control.label}}
+          <div class="input-group">
+            <div class="input-group-addon">$</div>
+            {{control.input}}
+            <div class="input-group-addon">.00</div>
+          </div>
+          <span class="help-block">
+            This is some help text
+          </span>
+        {{/bootstrap-input}}
+      {{/freestyle-usage}}
+    {{/collection.variant}}
+    {{#collection.variant key='input-text-horizontal'}}
+      {{#freestyle-usage "input-text-horizontal" title="Fancy Looking Input"}}
+        <form class="form-horizontal">
+          {{#bootstrap-input
+            value=value
+            label="Email"
+            placeholder="Email"
+            as |control|
+          }}
+            {{control.label classNames="col-sm-2 control-label"}}
+            <div class="col-sm-10">
+              {{control.input }}
+            </div>
+          {{/bootstrap-input}}
+        </form>
       {{/freestyle-usage}}
     {{/collection.variant}}
   {{/freestyle-collection}}

--- a/app/components/bootstrap/-input.js
+++ b/app/components/bootstrap/-input.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap-controls/components/bootstrap/-input';

--- a/app/components/bootstrap/-label.js
+++ b/app/components/bootstrap/-label.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap-controls/components/bootstrap/-label';

--- a/tests/integration/components/bootstrap/-input-test.js
+++ b/tests/integration/components/bootstrap/-input-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('bootstrap/-input', 'Integration | Component | bootstrap/ input', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{bootstrap/-input}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#bootstrap/-input}}
+      template block text
+    {{/bootstrap/-input}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/bootstrap/-label-test.js
+++ b/tests/integration/components/bootstrap/-label-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('bootstrap/-label', 'Integration | Component | bootstrap/ label', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{bootstrap/-label}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#bootstrap/-label}}
+      template block text
+    {{/bootstrap/-label}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Added ability to use bootstrap columns, input groups, hints/help text, any other desired mark-up. Currently only supported for `bootstrap-input` and `bootstrap-mask-input`, and maybe everything other than power-select and multi-select later (these two won't work as they already require blocks, a new component will be required for those elements). This is only for `0.x-stable` as master is currently bootstrap 4 which will be released as `1.0.0-alpha.0`. A cherry-pick of this for that branch is next.