### PR TITLE
Rollback invalid-feedback error message class

### DIFF
--- a/addon/templates/components/bootstrap/control-wrapper.hbs
+++ b/addon/templates/components/bootstrap/control-wrapper.hbs
@@ -4,10 +4,11 @@
       label=label
       srOnly=srOnly
     )
+    errors=errors
   )
 }}
 {{#if errors}}
-  <div class="invalid-feedback">
+  <div class="alert alert-danger" role="alert">
     {{#each errors as |error|}}
       <span>{{error.message}}</span>
     {{/each}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14425,7 +14425,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
         "string-width": "1.0.2"
       }


### PR DESCRIPTION
The `invalid-feedback` class needs to be used along side `is-invalid` on the input for it to work. Rolling back this change until respective components can be updated