### PR TITLE
Releases Link Broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ember-bootstrap-controls is a small library for quickly creating EmberJS forms t
 
 This README outlines the details of using and collaborating on this Ember addon.
 
-Checkout our [Releases](/releases/latest) or [Changelog](CHANGELOG.md) for what has changed.
+Checkout our [Releases](../../releases/latest) or [Changelog](CHANGELOG.md) for what has changed.
 
 Issues or ideas? Checkout our [contributing guide](CONTRIBUTING.md) for how to help contribute to this project.
 


### PR DESCRIPTION
Releases Link Broken. Points to (/releases/latest) but /latest throws a 404.

Pull Request Description:
The link to Releases in the read me is broken, results in 404. This fix updates the relative path to fix the problem

New Pull Request Checklist:
- [ ] Reviewed [contributing guidelines](CONTRIBUTING.md).
- [ ] [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
- [ ] Github issue added, if it exists.
- [ ] Added an entry to the [Changelog](CHANGELOG.md).
- [ ] All tests passing and new component tests include [ember-a11y-testing](https://github.com/ember-a11y/ember-a11y-testing) to test accessibility.
