### PR TITLE
onChange support for inputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
   * [#219](https://github.com/wildland/ember-bootstrap-controls/issues/219): Added an edit form that can self manage state for you. ([@jweakley][])
+  * [#227](https://github.com/wildland/ember-bootstrap-controls/issues/227): All inputs support onChange. ([@jweakley][])
 ### Changed
  * Updated tests to newest qunit patterns. ([@jweakley][])
  * Forms now share inputs as a component. ([@jweakley][])

--- a/addon/templates/components/bootstrap-inputs/-checkbox.hbs
+++ b/addon/templates/components/bootstrap-inputs/-checkbox.hbs
@@ -18,6 +18,7 @@
         srOnly=srOnly
         tabindex=tabindex
         onClick=onClick
+        change=onChange
       )
     )
   }}
@@ -32,6 +33,7 @@
     srOnly=srOnly
     tabindex=tabindex
     onClick=onClick
+    change=onChange
   }}
   {{bootstrap/-label
     classNames='form-check-label'

--- a/addon/templates/components/bootstrap-inputs/-email.hbs
+++ b/addon/templates/components/bootstrap-inputs/-email.hbs
@@ -27,6 +27,7 @@
           required=required
           srOnly=srOnly
           tabindex=tabindex
+          change=onChange
         )
       )
     }}
@@ -48,6 +49,7 @@
       srOnly=srOnly
       tabindex=tabindex
       helpId=control.helpId
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-floating-label-input.hbs
+++ b/addon/templates/components/bootstrap-inputs/-floating-label-input.hbs
@@ -10,6 +10,7 @@
   readonly=readonly
   required=required
   tabIndex=tabIndex
+  onChange=onChange
   as |text|
 }}
   {{text.input}}

--- a/addon/templates/components/bootstrap-inputs/-number.hbs
+++ b/addon/templates/components/bootstrap-inputs/-number.hbs
@@ -26,6 +26,7 @@
           step=step
           tabindex=tabindex
           value=value
+          change=onChange
         )
       )
     }}
@@ -46,6 +47,7 @@
       step=step
       tabindex=tabindex
       value=value
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-password.hbs
+++ b/addon/templates/components/bootstrap-inputs/-password.hbs
@@ -25,6 +25,7 @@
           required=required
           srOnly=srOnly
           tabindex=tabindex
+          change=onChange
         )
       )
     }}
@@ -45,6 +46,7 @@
       srOnly=srOnly
       tabindex=tabindex
       helpId=control.helpId
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-radio.hbs
+++ b/addon/templates/components/bootstrap-inputs/-radio.hbs
@@ -18,6 +18,7 @@
         required=required
         srOnly=srOnly
         onClick=onClick
+        change=onChange
       )
     )
   }}
@@ -32,6 +33,7 @@
     required=required
     srOnly=srOnly
     onClick=onClick
+    change=onChange
   }}
   {{bootstrap/-label
     classNames='form-check-label'

--- a/addon/templates/components/bootstrap-inputs/-range.hbs
+++ b/addon/templates/components/bootstrap-inputs/-range.hbs
@@ -24,6 +24,7 @@
           srOnly=srOnly
           step=step
           tabindex=tabindex
+          change=onChange
         )
       )
     }}
@@ -41,6 +42,7 @@
       srOnly=srOnly
       step=step
       tabindex=tabindex
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-search.hbs
+++ b/addon/templates/components/bootstrap-inputs/-search.hbs
@@ -27,6 +27,7 @@
           srOnly=srOnly
           tabindex=tabindex
           helpId=control.helpId
+          change=onChange
         )
       )
     }}
@@ -47,6 +48,7 @@
       srOnly=srOnly
       tabindex=tabindex
       helpId=control.helpId
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-tel.hbs
+++ b/addon/templates/components/bootstrap-inputs/-tel.hbs
@@ -25,6 +25,7 @@
           required=required
           srOnly=srOnly
           tabindex=tabindex
+          change=onChange
         )
       )
     }}
@@ -45,6 +46,7 @@
       srOnly=srOnly
       tabindex=tabindex
       helpId=control.helpId
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-text.hbs
+++ b/addon/templates/components/bootstrap-inputs/-text.hbs
@@ -27,6 +27,7 @@
           srOnly=srOnly
           tabindex=tabindex
           helpId=control.helpId
+          change=onChange
         )
       )
     }}
@@ -47,6 +48,7 @@
       srOnly=srOnly
       tabindex=tabindex
       helpId=control.helpId
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-time.hbs
+++ b/addon/templates/components/bootstrap-inputs/-time.hbs
@@ -27,6 +27,7 @@
           step=step
           tabindex=tabindex
           helpId=control.helpId
+          change=onChange
         )
       )
     }}
@@ -47,6 +48,7 @@
       step=step
       tabindex=tabindex
       helpId=control.helpId
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap-inputs/-url.hbs
+++ b/addon/templates/components/bootstrap-inputs/-url.hbs
@@ -26,6 +26,7 @@
           required=required
           tabindex=tabindex
           helpId=control.helpId
+          change=onChange
         )
       )
     }}
@@ -45,6 +46,7 @@
       required=required
       tabindex=tabindex
       helpId=control.helpId
+      change=onChange
     }}
     {{#if help}}
       {{control.help}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildland-labs/ember-bootstrap-controls",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildland-labs/ember-bootstrap-controls",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.0",
   "description": "Ember bootstrap form components.",
   "private": false,
   "keywords": [

--- a/tests/integration/components/bootstrap-inputs/-checkbox-test.js
+++ b/tests/integration/components/bootstrap-inputs/-checkbox-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Checkbox Input', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-checkbox label='label' value=true}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,12 +16,14 @@ module('Integration | Component | Checkbox Input', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-checkbox label='label' value=true}}`);
     assert.equal(findAll('input[type="checkbox"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-checkbox label='label' value=true}}`);
     assert.ok(find('input[type="checkbox"]:checked'));
 
@@ -29,8 +32,18 @@ module('Integration | Component | Checkbox Input', function(hooks) {
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-checkbox label=label value=true}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(1);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-checkbox onChange=onChange label='Label' value=true}}`);
+    await click('input');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-date-test.js
+++ b/tests/integration/components/bootstrap-inputs/-date-test.js
@@ -1,6 +1,6 @@
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Date', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     this.set('value', new Date());
     await render(hbs`{{bootstrap-inputs/-date label='label' value=value}}`);
     return a11yAudit(this.$()).then(() => {
@@ -16,6 +17,7 @@ module('Integration | Component | Bootstrap Inputs | Date', function(hooks) {
   });
 
   test('it renders a label and datepicker', async function(assert) {
+    assert.expect(2);
     this.set('value', new Date());
     await render(hbs`{{bootstrap-inputs/-date label='label' value=value}}`);
     assert.equal(findAll('input[type="date"]').length, 1);
@@ -23,15 +25,28 @@ module('Integration | Component | Bootstrap Inputs | Date', function(hooks) {
   });
 
   skip('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', new Date());
     await render(hbs`{{bootstrap-inputs/-date label='label' value=value}}`);
     assert.equal(find('input[type="date"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     this.set('value', new Date());
     await render(hbs`{{bootstrap-inputs/-date label=label value=value}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('value', new Date());
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-date onChange=onChange label='Label' value=value}}`);
+    await fillIn('input', 'Hello');
+    await typeIn('input', 'There');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-email-test.js
+++ b/tests/integration/components/bootstrap-inputs/-email-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Email Input', function(hook
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-email label='label' value='test@test.test'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,33 @@ module('Integration | Component | Bootstrap Inputs | Email Input', function(hook
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-email label='label' value='test@test.test'}}`);
     assert.equal(findAll('input[type="email"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', 'test@test.test');
     await render(hbs`{{bootstrap-inputs/-email label='label' value=value}}`);
     assert.equal(find('input[type="email"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-email label=label value='test@test.test'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-email  onChange=onChange label='label' value='test@test.test'}}`);
+    await fillIn('input', 'Hello@hi.com');
+    await typeIn('input', 'There@hi.com');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-floating-label-input-test.js
+++ b/tests/integration/components/bootstrap-inputs/-floating-label-input-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Floating Label Input', func
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-floating-label-input label='label' value='test@test.test'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,33 @@ module('Integration | Component | Bootstrap Inputs | Floating Label Input', func
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-floating-label-input label='label' value='test@test.test'}}`);
     assert.equal(findAll('input[type="text"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', 'some text');
     await render(hbs`{{bootstrap-inputs/-floating-label-input label='label' value=value}}`);
     assert.equal(find('input[type="text"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-floating-label-input label=label value='test@test.test'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-floating-label-input  onChange=onChange label='label' value='test@test.test'}}`);
+    await fillIn('input', 'Hello');
+    await typeIn('input', 'There');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-number-test.js
+++ b/tests/integration/components/bootstrap-inputs/-number-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Number', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-number label='label' value='42'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,33 @@ module('Integration | Component | Bootstrap Inputs | Number', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-number label='label' value='42'}}`);
     assert.equal(findAll('input[type="number"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', '42');
     await render(hbs`{{bootstrap-inputs/-number label='label' value=value}}`);
     assert.equal(find('input[type="number"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-number label=label value='42'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-number  onChange=onChange label='label' value='42'}}`);
+    await fillIn('input', '55');
+    await typeIn('input', '69');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-password-test.js
+++ b/tests/integration/components/bootstrap-inputs/-password-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Password', function(hooks) 
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-password label='label' value='Password'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,33 @@ module('Integration | Component | Bootstrap Inputs | Password', function(hooks) 
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-password label='label' value='Password'}}`);
     assert.equal(findAll('input[type="password"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', 'Password');
     await render(hbs`{{bootstrap-inputs/-password label='label' value=value}}`);
     assert.equal(find('input[type="password"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-password label=label value='Password'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-password onChange=onChange label='label' value='Password'}}`);
+    await fillIn('input', 'Hello');
+    await typeIn('input', 'There');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-radio-test.js
+++ b/tests/integration/components/bootstrap-inputs/-radio-test.js
@@ -1,6 +1,6 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | bootstrap inputs | radio', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-radio label='label' value=true}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,12 +16,14 @@ module('Integration | Component | bootstrap inputs | radio', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-radio label='label' value=true}}`);
     assert.equal(findAll('input[type="radio"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-radio label='label' value=true}}`);
     assert.ok(find('input[type="radio"]:checked'));
 
@@ -29,8 +32,18 @@ module('Integration | Component | bootstrap inputs | radio', function(hooks) {
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-radio label=label value=true}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  skip('it supports onChange', async function(assert) {
+    assert.expect(1);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-radio onChange=onChange label='Label' value=true}}`);
+    await click('input');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-range-test.js
+++ b/tests/integration/components/bootstrap-inputs/-range-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Range', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-range label='label' value=1}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,32 @@ module('Integration | Component | Bootstrap Inputs | Range', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-range label='label' value=1}}`);
     assert.equal(findAll('input[type="range"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', 1);
     await render(hbs`{{bootstrap-inputs/-range label='label' value=value}}`);
     assert.equal(find('input[type="range"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-range label=label value=1}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(1);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-range onChange=onChange label='label' value=1}}`);
+    await fillIn('input', 2);
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-search-test.js
+++ b/tests/integration/components/bootstrap-inputs/-search-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Search', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-search label='label' value='Search Term'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,33 @@ module('Integration | Component | Bootstrap Inputs | Search', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-search label='label' value='Search Term'}}`);
     assert.equal(findAll('input[type="search"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', 'Search Term');
     await render(hbs`{{bootstrap-inputs/-search label='label' value=value}}`);
     assert.equal(find('input[type="search"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-search label=label value='Search Term'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-search onChange=onChange label='label' value='Search Term'}}`);
+    await fillIn('input', 'Hello');
+    await typeIn('input', 'There');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-tel-test.js
+++ b/tests/integration/components/bootstrap-inputs/-tel-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component |  Bootstrap Inputs | Telephone', function(hooks
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-tel label='label' value='555-555-5555'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,33 @@ module('Integration | Component |  Bootstrap Inputs | Telephone', function(hooks
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-tel label='label' value='555-555-5555'}}`);
     assert.equal(findAll('input[type="tel"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', '555-555-5555');
     await render(hbs`{{bootstrap-inputs/-tel label='label' value=value}}`);
     assert.equal(find('input[type="tel"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-tel label=label value='555-555-5555'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-tel onChange=onChange label='label' value='555-555-5555'}}`);
+    await fillIn('input', '123-456-7890');
+    await typeIn('input', '098-765-4321');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-text-test.js
+++ b/tests/integration/components/bootstrap-inputs/-text-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Text', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-text label='label' value='Password'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,20 +16,33 @@ module('Integration | Component | Bootstrap Inputs | Text', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-text label='label' value='Password'}}`);
     assert.equal(findAll('input[type="text"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', 'Password');
     await render(hbs`{{bootstrap-inputs/-text label='label' value=value}}`);
     assert.equal(find('input[type="text"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-text label=label value='Password'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-text onChange=onChange label='label' value='Password'}}`);
+    await fillIn('input', 'Hello');
+    await typeIn('input', 'There');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-time-test.js
+++ b/tests/integration/components/bootstrap-inputs/-time-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Time', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-time label='label' value='12:12'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,21 +16,33 @@ module('Integration | Component | Time', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-time label='label' value='12:12'}}`);
     assert.equal(findAll('input[type="time"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', '12:12');
     await render(hbs`{{bootstrap-inputs/-time label='label' value=value}}`);
-
     assert.equal(find('input[type="time"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-time label=label value='12:12'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-time onChange=onChange label='label' value='12:12'}}`);
+    await fillIn('input', '11:11');
+    await typeIn('input', '10:10');
   });
 });

--- a/tests/integration/components/bootstrap-inputs/-url-test.js
+++ b/tests/integration/components/bootstrap-inputs/-url-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import { render, find, findAll, fillIn, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
@@ -8,6 +8,7 @@ module('Integration | Component | Bootstrap Inputs | Url', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it has no a11y errors', async function(assert) {
+    assert.expect(1);
     await render(hbs`{{bootstrap-inputs/-url label='label' value='http://wild.land'}}`);
     return a11yAudit(this.$()).then(() => {
       assert.ok(true, 'no a11y errors found!');
@@ -15,21 +16,33 @@ module('Integration | Component | Bootstrap Inputs | Url', function(hooks) {
   });
 
   test('it renders a label and input', async function(assert) {
+    assert.expect(2);
     await render(hbs`{{bootstrap-inputs/-url label='label' value='http://wild.land'}}`);
     assert.equal(findAll('input[type="url"]').length, 1);
     assert.equal(findAll('label').length, 1);
   });
 
   test('it uses value', async function(assert) {
+    assert.expect(1);
     this.set('value', 'http://wild.land');
     await render(hbs`{{bootstrap-inputs/-url label='label' value=value}}`);
-
     assert.equal(find('input[type="url"]').value, this.get('value'));
   });
 
   test('it uses label', async function(assert) {
+    assert.expect(1);
     this.set('label', 'Some label');
     await render(hbs`{{bootstrap-inputs/-url label=label value='http://wild.land'}}`);
     assert.equal(find('label').textContent.trim(), this.get('label'));
+  });
+
+  test('it supports onChange', async function(assert) {
+    assert.expect(2);
+    this.set('onChange', () => {
+      assert.ok(true);
+    });
+    await render(hbs`{{bootstrap-inputs/-url onChange=onChange label='label' value='http://wild.land'}}`);
+    await fillIn('input', 'http://wild.land/tests');
+    await typeIn('input', 'http://wild.land/ember');
   });
 });


### PR DESCRIPTION
Pull Request Description:
Inputs now support `onChange`. Fixes #227.

New Pull Request Checklist:
- [x] Reviewed [contributing guidelines](CONTRIBUTING.md).
- [x] [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
- [x] Github issue added, if it exists.
- [x] Added an entry to the [Changelog](CHANGELOG.md).
- [x] All tests passing: run `npm test`.
- [x] New component tests include [ember-a11y-testing](https://github.com/ember-a11y/ember-a11y-testing) to test accessibility.
