### PR TITLE
Added onInput to search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+  * `bootstrap/simple-form` now has button components. ([@jweakley][])
   * Search input now support `onInput`. ([@jweakley][])
   * [#219](https://github.com/wildland/ember-bootstrap-controls/issues/219): Added an edit form that can self manage state for you. ([@jweakley][])
   * [#227](https://github.com/wildland/ember-bootstrap-controls/issues/227): All inputs support onChange. ([@jweakley][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+  * Search input now support `onInput`. ([@jweakley][])
   * [#219](https://github.com/wildland/ember-bootstrap-controls/issues/219): Added an edit form that can self manage state for you. ([@jweakley][])
   * [#227](https://github.com/wildland/ember-bootstrap-controls/issues/227): All inputs support onChange. ([@jweakley][])
 ### Changed

--- a/addon/templates/components/bootstrap-inputs/-search.hbs
+++ b/addon/templates/components/bootstrap-inputs/-search.hbs
@@ -13,7 +13,7 @@
         help=(component control.help)
         control=control
         input=(component 'bootstrap/-input'
-          value=value
+          value=_value
           elementId=control.inputId
           type='search'
           disabled=disabled
@@ -28,13 +28,14 @@
           tabindex=tabindex
           helpId=control.helpId
           change=onChange
+          input=(action 'onInput')
         )
       )
     }}
   {{else}}
     {{control.label}}
     {{bootstrap/-input
-      value=value
+      value=_value
       elementId=control.inputId
       type='search'
       disabled=disabled
@@ -49,6 +50,7 @@
       tabindex=tabindex
       helpId=control.helpId
       change=onChange
+      input=(action 'onInput')
     }}
     {{#if help}}
       {{control.help}}

--- a/addon/templates/components/bootstrap/edit-form.hbs
+++ b/addon/templates/components/bootstrap/edit-form.hbs
@@ -16,5 +16,4 @@
     )
     inputs=(component 'bootstrap/form/-inputs' disabled=(readonly isDisabled))
   )
-
 }}

--- a/addon/templates/components/bootstrap/simple-form.hbs
+++ b/addon/templates/components/bootstrap/simple-form.hbs
@@ -1,5 +1,8 @@
 {{yield
   (hash
     inputs=(component 'bootstrap/form/-inputs')
+    submitButton=(component 'bootstrap-button' type='submit' buttonText='Submit')
+    resetButton=(component 'bootstrap-button' type='reset' buttonText='Reset')
+    normalButton=(component 'bootstrap-button' type='button')
   )
 }}

--- a/tests/integration/components/bootstrap-inputs/-search-test.js
+++ b/tests/integration/components/bootstrap-inputs/-search-test.js
@@ -23,10 +23,13 @@ module('Integration | Component | Bootstrap Inputs | Search', function(hooks) {
   });
 
   test('it uses value', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
     this.set('value', 'Search Term');
+    this.set('newValue', 'Some Other Search Term');
     await render(hbs`{{bootstrap-inputs/-search label='label' value=value}}`);
     assert.equal(find('input[type="search"]').value, this.get('value'));
+    await fillIn('input', this.get('newValue'));
+    assert.equal(this.get('value'), this.get('newValue'));
   });
 
   test('it uses label', async function(assert) {
@@ -44,5 +47,15 @@ module('Integration | Component | Bootstrap Inputs | Search', function(hooks) {
     await render(hbs`{{bootstrap-inputs/-search onChange=onChange label='label' value='Search Term'}}`);
     await fillIn('input', 'Hello');
     await typeIn('input', 'There');
+  });
+
+  test('it supports onInput', async function(assert) {
+    assert.expect(1);
+    this.set('inputValue', 'How To Program');
+    this.set('onInput', (value) => {
+      assert.equal(value, this.get('inputValue'));
+    });
+    await render(hbs`{{bootstrap-inputs/-search onInput=onInput onInputDebounce=0 label='label' value='Search Term'}}`);
+    await fillIn('input', this.get('inputValue'));
   });
 });


### PR DESCRIPTION
Pull Request Description:
Added the ability to have an `onInput` action for Search inputs. This is debounced at 500ms default.

New Pull Request Checklist:
- [x] Reviewed [contributing guidelines](CONTRIBUTING.md).
- [x] [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
- [x] Github issue added, if it exists.
- [x] Added an entry to the [Changelog](CHANGELOG.md).
- [x] All tests passing: run `npm test`.
- [x] New component tests include [ember-a11y-testing](https://github.com/ember-a11y/ember-a11y-testing) to test accessibility.
